### PR TITLE
fix: save to forage before create workflow

### DIFF
--- a/frontend/src/features/workflowEditor/components/WorkflowEditor.tsx
+++ b/frontend/src/features/workflowEditor/components/WorkflowEditor.tsx
@@ -143,6 +143,7 @@ export const WorkflowsEditorComponent: React.FC = () => {
 
   const handleSaveWorkflow = useCallback(async () => {
     try {
+      await saveDataToLocalForage();
       setBackdropIsOpen(true);
       if (!workspace?.id) {
         throw new Error("No selected Workspace");
@@ -231,16 +232,12 @@ export const WorkflowsEditorComponent: React.FC = () => {
       const nodeData = event.dataTransfer.getData("application/reactflow");
       const { ...data } = JSON.parse(nodeData);
 
-      console.log("orientation", orientation);
-
       const newNodeData: DefaultNode["data"] = {
         name: data.name,
         style: data.style,
         validationError: false,
         orientation,
       };
-
-      console.log("newNodeData", newNodeData);
 
       const newNode = {
         id: getId(data.id),


### PR DESCRIPTION
Now, the workflow editor save every 3 seconds the nodes to the forage, this create a issue where we can create a workflow with missing pieces if the data was not send to the forage yet. 

This fix this error just saving to the forage before create the workflow