### PR TITLE
fix: delete workspace from local storage on leave

### DIFF
--- a/frontend/src/context/workspaces/workspaces.tsx
+++ b/frontend/src/context/workspaces/workspaces.tsx
@@ -109,8 +109,7 @@ export const WorkspacesProvider: FC<IWorkspacesProviderProps> = ({
         .then(() => {
           toast.success(`User removed successfully from workspace.`);
           const storageWorkspace = JSON.parse(
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            localStorage.getItem("workspace")!,
+            localStorage.getItem("workspace") ?? "{}",
           );
           if (storageWorkspace && storageWorkspace.id === workspaceId) {
             localStorage.removeItem("workspace");

--- a/frontend/src/context/workspaces/workspaces.tsx
+++ b/frontend/src/context/workspaces/workspaces.tsx
@@ -108,6 +108,14 @@ export const WorkspacesProvider: FC<IWorkspacesProviderProps> = ({
       removeUserWorkspace({ workspaceId, userId })
         .then(() => {
           toast.success(`User removed successfully from workspace.`);
+          const storageWorkspace = JSON.parse(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            localStorage.getItem("workspace")!,
+          );
+          if (storageWorkspace && storageWorkspace.id === workspaceId) {
+            localStorage.removeItem("workspace");
+            setWorkspace(null);
+          }
           void workspacesRefresh();
         })
         .catch((error) => {

--- a/frontend/src/features/workspaces/components/workspaces/WorkspaceListItem.tsx
+++ b/frontend/src/features/workspaces/components/workspaces/WorkspaceListItem.tsx
@@ -16,7 +16,6 @@ import {
   Tooltip,
   Chip,
 } from "@mui/material";
-import Stack from "@mui/material/Stack";
 import { type IWorkspaceSummary } from "context/workspaces/types";
 import { type FC } from "react";
 import { useNavigate } from "react-router-dom";


### PR DESCRIPTION
Fix #229

The problem was that we were not updating the workspace state to null and clearing local storage, as we do in the delete operation. When leaving the workspace, I deleted the workspace from local storage and set the workspace state to null, similar to the workspace delete operation we currently have. Additionally, I removed an unnecessary import from my previous PR.