### PR TITLE
fix: use alpine linux socat image

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -370,7 +370,7 @@ services:
 
   # Domino Docker Proxy
   docker-proxy:
-    image: bobrik/socat
+    image: alpine/socat
     container_name: domino-docker-proxy
     command: "TCP4-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock"
     ports:

--- a/src/domino/cli/utils/docker-compose-without-database.yaml
+++ b/src/domino/cli/utils/docker-compose-without-database.yaml
@@ -322,7 +322,7 @@ services:
 
   # Domino Docker proxy
   docker-proxy:
-    image: bobrik/socat
+    image: alpine/socat
     container_name: domino-docker-proxy
     command: "TCP4-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock"
     ports:

--- a/src/domino/cli/utils/docker-compose.yaml
+++ b/src/domino/cli/utils/docker-compose.yaml
@@ -353,7 +353,7 @@ services:
 
   # Domino Docker proxy
   docker-proxy:
-    image: bobrik/socat
+    image: alpine/socat
     container_name: domino-docker-proxy
     command: "TCP4-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock"
     ports:


### PR DESCRIPTION
```

[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/bobrik/socat:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

```