### PR TITLE
fix(frontend): overflow on flex components

### DIFF
--- a/frontend/src/components/PrivateLayout/index.tsx
+++ b/frontend/src/components/PrivateLayout/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Container } from "@mui/material";
 import { type FC, type ReactNode } from "react";
 
+import { DrawerHeader } from "./header/drawerMenu.style";
 import { Header } from "./header/header";
 
 interface Props {
@@ -9,10 +10,16 @@ interface Props {
 
 export const PrivateLayout: FC<Props> = ({ children }) => {
   return (
-    <Box sx={{ display: "flex", width: "100%", marginTop: "64px" }}>
+    <Box sx={{ display: "flex" }}>
       <Header />
 
-      <Container component="main" maxWidth={false} sx={{ padding: 3 }}>
+      <Container
+        component="main"
+        maxWidth={false}
+        sx={{ padding: 3, overflow: "auto" }}
+      >
+        <DrawerHeader />
+
         <Box sx={{ paddingLeft: 0 }}>{children}</Box>
       </Container>
     </Box>


### PR DESCRIPTION
Fix overflow of flex elements in lower resolutions

Before:

![image](https://github.com/Tauffer-Consulting/domino/assets/54302847/9486ba66-430e-489a-9407-754a37815dfd)


After: 

![image](https://github.com/Tauffer-Consulting/domino/assets/54302847/1a262ecf-f297-4a76-ae63-d5019dfd4ed1)
