### PR TITLE
fix building erro

### DIFF
--- a/Dockerfile-airflow-domino.prod
+++ b/Dockerfile-airflow-domino.prod
@@ -7,5 +7,5 @@ USER root
 RUN apt-get update
 
 USER airflow
-RUN pip install --upgrade pip \
+RUN pip install --upgrade pip &&\
     pip install domino-py[airflow]


### PR DESCRIPTION
fix buid erro ,erro info
```bash
 => [2/3] RUN apt-get update                                                                                                                                                    3.8s
 => ERROR [3/3] RUN pip install --upgrade pip     pip install domino-py[airflow]                                                                                                3.1s
------
 > [3/3] RUN pip install --upgrade pip     pip install domino-py[airflow]:
2.485 Requirement already satisfied: pip in /usr/local/lib/python3.9/site-packages (23.0.1)
2.613 Collecting pip
2.632   Downloading pip-26.0.1-py3-none-any.whl (1.8 MB)
2.664      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 64.5 MB/s eta 0:00:00
2.909 ERROR: Could not find a version that satisfies the requirement install (from versions: none)
2.910 ERROR: No matching distribution found for install
3.014
3.014 [notice] A new release of pip is available: 23.0.1 -> 26.0.1
3.014 [notice] To update, run: pip install --upgrade pip
------
Dockerfile-airflow-domino.prod:10
--------------------
   9 |     USER airflow
  10 | >>> RUN pip install --upgrade pip \
  11 | >>>     pip install domino-py[airflow]
--------------------
ERROR: failed to build: failed to solve: process "/bin/bash -o pipefail -o errexit -o nounset -o nolog -c pip install --upgrade pip     pip install domino-py[airflow]" did not complete successfully: exit code: 1


```

before
<img width="2196" height="544" alt="image" src="https://github.com/user-attachments/assets/683663c8-e551-4792-b4b2-3bd6af25722c" />

after
<img width="2216" height="494" alt="image" src="https://github.com/user-attachments/assets/6567ef10-e5e0-46b1-9205-6d27e6794ce1" />
